### PR TITLE
Instead of attempting to override the message in our custom exception…

### DIFF
--- a/ZeroSSL.Net/Model/Exceptions/EmptyAPIKeyException.cs
+++ b/ZeroSSL.Net/Model/Exceptions/EmptyAPIKeyException.cs
@@ -8,6 +8,8 @@ namespace ZeroSSL.Net.Model.Exceptions
 {
     public class EmptyAPIKeyException : Exception
     {
-        public string Message = "API Key is empty or null.";
+        public EmptyAPIKeyException() : base("API Key is empty or null.")
+        {
+        }
     }
 }


### PR DESCRIPTION
… - we call the base exception constructor.